### PR TITLE
some revisions to the napkin calculations

### DIFF
--- a/Access Carbon Footprint.ipynb
+++ b/Access Carbon Footprint.ipynb
@@ -11,8 +11,12 @@
     "> According to the [American Council for an Energy-Efficient Economy](https://www.emergeinteractive.com/wp-content/uploads/2020/02/aceee-cached-research.pdf) it takes 5.12 kWh of electricity per gigabyte of transferred data. And according to the [Department of Energy](https://www.emergeinteractive.com/wp-content/uploads/2020/02/DOE-CO2-Emissions-Generation-Electric-Power-2000.pdf) the average US power plant expends 600 grams of carbon dioxide for every kWh generated. That means that transferring 1GB of data produces 3kg of CO2. [https://www.emergeinteractive.com/insights/detail/does-irresponsible-web-development-contribute-to-global-warming/]\n",
     "\n",
     "\n",
-    "We could get actual numbers from our Zoom webinars in session, but let's say that this is our average\n",
+    "Originally I thought that this is our average\n",
     "> A one-hour high-definition video call consumes about 540 MB per person. [https://gerrymcgovern.com/the-hidden-pollution-cost-of-online-meetings/]\n",
+    "\n",
+    "But some observation shows that it's more like for me.  \n",
+    "![](images/access_goat_live_stream.PNG)\n",
+    "I'm not sure if there would be variation in that per participant. Obviously the speakers would also be sending data. For now assuming that that value is negligable. This was on the higher end of what I observed.  I think 1000 kb/s is a more acurate value.\n",
     "\n",
     "Access Conference runs 28.5 hours\n",
     "- Monday: 8:30 to 3:30 (7 hours)\n",
@@ -28,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {
     "scrolled": true
    },
@@ -58,34 +62,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's say that there is 60% attendance at any given time.  \n",
+    "~Let's say that there is 60% attendance at any given time.~  By observation there were 25% attendance on Thursday.  Even if we say this is 30%\n",
     "\n",
-    "28.5 hours \\* 464 people \\* 0.6 * 540 MB/(person hour) \\* 0.001 GB/MB \\* 3 kg CO2e/GB \\* 0.001 tonne/kg"
+    "28.5 hours \\* 464 people \\* 30% attendance \\* 1 MB/(person seconds) \\* 0.001 GB/MB \\* 60 seconds/minute \\* 60 minutes/hour \\* 3 kg CO2e/GB \\* 0.001 tonne/kg"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"12.853728 tonne CO2e for the 2020 Access Conference\""
+       "\"42.845760000000006 tonne CO2e for the 2020 Access Conference\""
       ]
      },
-     "execution_count": 29,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "\"#{28.5*464*0.6*540*0.001*3*0.001} tonne CO2e for the 2020 Access Conference\""
+    "\"#{28.5*464*0.3*1*0.001*60*60*3*0.001} tonne CO2e for the 2020 Access Conference\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -93,8 +97,8 @@
      "output_type": "stream",
      "text": [
       "total distance travelled: 1034546 km\n",
-      "total distance flown: 424690 km (average: 1490 km) by 285 people\n",
-      "total distance driven: 10284 km (average: 57 km) by 179 people\n"
+      "total distance flown: 988817 km (average: 3469 km) by 285 people\n",
+      "total distance driven: 45729 km (average: 255 km) by 179 people\n"
      ]
     }
    ],
@@ -120,10 +124,10 @@
     "    lon = geocoded.first.data['lon']    \n",
     "    distance = Geocoder::Calculations.distance_between(confcoords,[lat, lon]).round\n",
     "    if distance < 1000\n",
-    "        distance_less_than_1000 += distance\n",
+    "        distance_less_than_1000 += distance*row['count'].to_i\n",
     "        people_travelleing_less_than_1000 +=row['count'].to_i\n",
     "    else\n",
-    "        distance_greater_than_1000 += distance\n",
+    "        distance_greater_than_1000 += distance*row['count'].to_i\n",
     "        people_travelleing_greater_than_1000 +=row['count'].to_i\n",
     "    end\n",
     "    total_distance += distance*row['count'].to_i\n",
@@ -143,44 +147,44 @@
     "> The average new car emits 120.1g/km of CO2 [https://www.lightfoot.co.uk/news/2017/10/04/how-much-co2-does-a-car-emit-per-year/]\n",
     "\n",
     "\n",
-    "Trying to find an estimate for the flights so far the best I've found is using a flight with the average distance.  Turns out Vancouver to Whitehorse is about that far.\n",
+    "Trying to find an estimate for the flights so far the best I've found is using a flight with the average distance.  Turns out Vancouver to New Orleans is about that far but there aren't any direct flights.  The distance is somewhere between Toronto and Ottawa. Let's use Ottawa's values.\n",
     "\n",
     "|Dep Airport|Arr Airport|Distance (KM)|Aircraft|Aircraft Fuel Burn/leg (KG)|Passenger CO2/pax/leg (KG)|\n",
     "|--|--|--|--|--|--|\n",
-    "|YVR|YXY|1482.0|319, 320, 734, 735, CR9|6730.7|154.9|\n",
-    "|YXY|YVR|1482.0|319, 320, 734, 735, CR9|6729.2|154.9| \n",
+    "|YVR|YOW|3550.0|319, 320, 321, 736, 73H, 73W|13805.5|275.3|\n",
+    "|YOW|YVR|3550.0|319, 320, 321, 736, 73H, 73W|13786.8|275.6|\n",
     "\n",
     "[https://www.icao.int/environmental-protection/CarbonOffset/Pages/default.aspx]\n",
     "\n",
-    "((120.1 g CO2e/km \\* 10284 km \\* 0.001 kg/g) + (154.9 kg CO2e/(person flight) \\* 2 flights \\* 285 people))\\* 0.001 tonne/kg"
+    "((120.1 g CO2e/km \\* 45729 km \\* 0.001 kg/g) + (275.3 kg CO2e + 275.6 kg CO2e)/person \\* 285 people))\\* 0.001 tonne/kg"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\"89.5281084 tonne CO2e if Access had been in Vancouver\""
+       "\"162.49855290000005 tonne CO2e if Access had been in Vancouver\""
       ]
      },
-     "execution_count": 36,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "\"#{((120.1 * 10284 * 0.001) + (154.9 * 2 * 285))* 0.001} tonne CO2e if Access had been in Vancouver\""
+    "\"#{((120.1 * 45729  * 0.001) + ((275.3+275.6) * 285))* 0.001} tonne CO2e if Access had been in Vancouver\""
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Virtual Access (🌲🌲): 12.853728 tonnes CO2e / 7 tonnes CO2e per tree ~2\n",
-    "- Physical Access (🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲): 90 tonnes CO2e / 7 tonnes CO2e per tree ~13"
+    "- Virtual Access (🌲🌲🌲🌲🌲🌲): 42.8 tonnes CO2e / 7 tonnes CO2e per tree ~6\n",
+    "- Physical Access (🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲🌲): 162.5 tonnes CO2e / 7 tonnes CO2e per tree ~23"
    ]
   },
   {

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                 <p class="py-2">We saved:</p>
                 <p class="py-2"><span class="display-4">76.68</span><br/>tonnes CO2e for our virtual conference<br/></p>
                 <p class="py-2">compared to a traditional single-site, in-person conference.</p>
-                <a class="btn btn-outline-secondary" href="https://github.com/AccessLibCon/CarbonEmissions/blob/napkin_calculations/Access%20Carbon%20Footprint.ipynb">See our napkin calculations</a>
+                <a class="btn btn-outline-secondary" href="https://github.com/AccessLibCon/CarbonEmissions/blob/main/Access%20Carbon%20Footprint.ipynb">See our napkin calculations</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
From observations during the Thursday session as a pannelist I noticed that the bandwidth was higher than my original
estimate.  This might just be because I was a pannelist at the time.  I'll follow up today.  At the same time I
noticed that my estimate of 60% attendance might be high.  There were 120ish people on the call.

I was also thinking a bit more about the average distances travelled and the fact that they seemed too small.
Reflecting on the map that Julia showed off, most people were in EST and there were even some from the UK. Whitehorse
seemed too close to be the average.  There is an error in the calculation.  I tabulated the total people in the
fly and drive situation correctly but I forgot to account for the duplication of distances in calculating the total
distances used in the average.

Both these changes result in way higher costs. It also results in a way higher savings!